### PR TITLE
feat: Add Tkinter launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ Only edit this file if you know what you're doing.
             - `notify_mode` - any desired combination of the following
                 - `SERVER_EVENTS = 1, PLAYER_CONN_EVENTS = 2, PLAYER_OTHER_EVENTS = 4`
 
+# Launcher
+
+A Tkinter-based GUI launcher is available for users who prefer a graphical interface over the command line.
+
+## Usage
+
+1. Make sure you have Python installed.
+2. Run the `launcher.py` script from the root directory:
+   ```bash
+   python launcher.py
+   ```
+3. The launcher window will open.
+   - Click the "Start Server" button to start the ProtonMC server. The server output will be displayed in the text area.
+   - Click the "Stop Server" button to stop the server.
+
 # Telegram Notifications
 
 ProtonMC can send Telegram messages for certain server events. Here's how to set it up.

--- a/launcher.py
+++ b/launcher.py
@@ -38,13 +38,14 @@ class Launcher(tk.Tk):
         self.output_area.insert(tk.INSERT, "Starting server...\n")
 
         self.process = subprocess.Popen(
-            ["python", "backend/main.py"],
+            ["python", "main.py"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
             universal_newlines=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0,
+            cwd="backend"
         )
 
         self.thread = threading.Thread(target=self.read_output)

--- a/launcher.py
+++ b/launcher.py
@@ -24,6 +24,17 @@ class Launcher(tk.Tk):
     def start_server(self):
         self.start_button.config(state=tk.DISABLED)
         self.stop_button.config(state=tk.NORMAL)
+        self.output_area.insert(tk.INSERT, "Installing dependencies...\n")
+
+        try:
+            subprocess.check_call(["python", "-m", "pip", "install", "-r", "backend/requirements.txt"])
+            self.output_area.insert(tk.INSERT, "Dependencies installed successfully.\n")
+        except subprocess.CalledProcessError as e:
+            self.output_area.insert(tk.INSERT, f"Error installing dependencies: {e}\n")
+            self.start_button.config(state=tk.NORMAL)
+            self.stop_button.config(state=tk.DISABLED)
+            return
+
         self.output_area.insert(tk.INSERT, "Starting server...\n")
 
         self.process = subprocess.Popen(

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,70 @@
+import tkinter as tk
+from tkinter import scrolledtext
+import subprocess
+import threading
+import os
+
+class Launcher(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("ProtonMC Launcher")
+        self.geometry("800x600")
+
+        self.process = None
+
+        self.start_button = tk.Button(self, text="Start Server", command=self.start_server)
+        self.start_button.pack(pady=10)
+
+        self.stop_button = tk.Button(self, text="Stop Server", command=self.stop_server, state=tk.DISABLED)
+        self.stop_button.pack(pady=10)
+
+        self.output_area = scrolledtext.ScrolledText(self, wrap=tk.WORD, bg="black", fg="white")
+        self.output_area.pack(pady=10, padx=10, expand=True, fill="both")
+
+    def start_server(self):
+        self.start_button.config(state=tk.DISABLED)
+        self.stop_button.config(state=tk.NORMAL)
+        self.output_area.insert(tk.INSERT, "Starting server...\n")
+
+        self.process = subprocess.Popen(
+            ["python", "backend/main.py"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            universal_newlines=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
+        )
+
+        self.thread = threading.Thread(target=self.read_output)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def stop_server(self):
+        if self.process:
+            self.process.terminate()
+            self.process.wait()
+            self.process = None
+            self.output_area.insert(tk.INSERT, "\nServer stopped.\n")
+        self.start_button.config(state=tk.NORMAL)
+        self.stop_button.config(state=tk.DISABLED)
+
+    def read_output(self):
+        for line in iter(self.process.stdout.readline, ''):
+            self.output_area.insert(tk.INSERT, line)
+            self.output_area.see(tk.END)
+        self.process.stdout.close()
+        self.process.wait()
+        self.output_area.insert(tk.INSERT, "\nServer process finished.\n")
+        self.start_button.config(state=tk.NORMAL)
+        self.stop_button.config(state=tk.DISABLED)
+
+    def on_closing(self):
+        if self.process:
+            self.stop_server()
+        self.destroy()
+
+if __name__ == "__main__":
+    app = Launcher()
+    app.protocol("WM_DELETE_WINDOW", app.on_closing)
+    app.mainloop()


### PR DESCRIPTION
This commit introduces a new Tkinter-based GUI launcher for the ProtonMC server. The launcher provides a user-friendly way to start and stop the server, with a text area to display the server's output.

The main features of the launcher are:
- A "Start Server" button to launch the backend server.
- A "Stop Server" button to terminate the server process.
- A scrolled text area to view the server's console output in real-time.
- Instructions on how to use the launcher have been added to the `README.md` file.

This launcher is intended to simplify the process of running the server for users who are not comfortable with the command line.